### PR TITLE
Fix pass, fails, errors and waives evaluation

### DIFF
--- a/mrglog.py
+++ b/mrglog.py
@@ -597,10 +597,10 @@ class MRGLog(MRGLogger):
                 ColorFormatter.format_color("%-5s" % _result, COLORS[_result]),
                 ColorFormatter.format_bold("%-5s" % (
                     self.fails +
-                    self.pass_ +
+                    self.passes +
                     self.waives)),
                 ColorFormatter.format_color(
-                    "%-5s" % (self.pass_),
+                    "%-5s" % (self.passes),
                     COLORS['PASS']),
                 ColorFormatter.format_color(
                     "%-5s" % (self.fails),
@@ -905,7 +905,7 @@ class MRGLog(MRGLogger):
                     'tag': 'testid', 'attrs': {'result': str(result).upper()}})
 
     @property
-    def pass_(self):
+    def passes(self):
         """ getter for number of pass """
         return len(self.test_results["pass"])
 

--- a/mrglog.py
+++ b/mrglog.py
@@ -571,9 +571,9 @@ class MRGLog(MRGLogger):
             self.log(LOG_LEVEL, '=' * LINE_LENGTH, noxml=True)
 
         if self.log_lvl < 1:
-            if self.test_results["errors"] != 0:
+            if self.errors != 0:
                 _result = "ERROR"
-            elif self.test_results["fails"] != 0:
+            elif self.fails != 0:
                 _result = "FAIL"
             else:
                 _result = "PASS"

--- a/mrglog.py
+++ b/mrglog.py
@@ -596,20 +596,20 @@ class MRGLog(MRGLogger):
                 " #ERRORS: %s #WAIVES: %s",
                 ColorFormatter.format_color("%-5s" % _result, COLORS[_result]),
                 ColorFormatter.format_bold("%-5s" % (
-                    len(self.test_results["fails"]) +
-                    len(self.test_results["pass"]) +
-                    len(self.test_results["waives"]))),
+                    self.fails +
+                    self.pass_ +
+                    self.waives)),
                 ColorFormatter.format_color(
-                    "%-5s" % (len(self.test_results["pass"])),
+                    "%-5s" % (self.pass_),
                     COLORS['PASS']),
                 ColorFormatter.format_color(
-                    "%-5s" % (len(self.test_results["fails"])),
+                    "%-5s" % (self.fails),
                     COLORS[_result]),
                 ColorFormatter.format_color(
-                    "%-3s" % (len(self.test_results["errors"])),
+                    "%-3s" % (self.errors),
                     COLORS[_result]),
                 ColorFormatter.format_bold(
-                    "%s" % (len(self.test_results["waives"]))),
+                    "%s" % (self.waives)),
                 noxml=True)
             if IS_LINUX:
                 try:
@@ -905,6 +905,11 @@ class MRGLog(MRGLogger):
                     'tag': 'testid', 'attrs': {'result': str(result).upper()}})
 
     @property
+    def pass_(self):
+        """ getter for number of pass """
+        return len(self.test_results["pass"])
+
+    @property
     def fails(self):
         """ getter for number of fails """
         return len(self.test_results["fails"])
@@ -913,6 +918,11 @@ class MRGLog(MRGLogger):
     def errors(self):
         """ getter for number of errors"""
         return len(self.test_results["errors"])
+
+    @property
+    def waives(self):
+        """ getter for number of waives"""
+        return len(self.test_results["waives"])
 
     def rlFailsNumber(self):
         """ return number of fails """


### PR DESCRIPTION
There is problem with assigning the result which is always evaluated as ERROR, because `self.test_results["errors"]` (and also `"fails"`, `"pass"` and `"waives"` are lists not simple integers.
When fixing this issue, I also utilized the property `errors`, `fails` and add new one for `pass` and `waives`.